### PR TITLE
Implemented theme switcher using react-switch

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,6 @@
     120
   ],
   "javascript.preferences.quoteStyle": "single",
-  "typescript.preferences.quoteStyle": "single"
+  "typescript.preferences.quoteStyle": "single",
+  "editor.formatOnSave": true
 }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "react-dom": "^18.3.1",
     "react-intl": "^6.6.8",
     "react-scripts": "5.0.1",
+    "react-switch": "^7.0.0",
     "styled-components": "^6.1.13",
     "typescript": "^4.4.2"
   },

--- a/src/components/Home/Header.tsx
+++ b/src/components/Home/Header.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+import ThemeToggle from '../ThemeToggle/ThemeToggle';
+import { Column, Container, Row } from '../Layout';
+import { StyledHeader } from './styles';
+
+const Header = () => {
+  return (
+    <StyledHeader>
+      <Container>
+        <Row>
+          <Column size='full'>
+            <ThemeToggle />
+          </Column>
+        </Row>
+      </Container>
+    </StyledHeader>
+  );
+
+};
+
+export default Header;
+

--- a/src/components/Home/Home.tsx
+++ b/src/components/Home/Home.tsx
@@ -3,6 +3,7 @@ import { ColorSchemeContext } from '../../context/ColorSchemeContext';
 
 import Footer from './Footer';
 import Main from './Main';
+import Header from './Header';
 
 
 const Home = () => {
@@ -14,6 +15,7 @@ const Home = () => {
 
   return (
     <React.Fragment>
+      <Header />
       <Main />
       <Footer />
     </React.Fragment>

--- a/src/components/Home/styles.tsx
+++ b/src/components/Home/styles.tsx
@@ -16,6 +16,20 @@ export const StyledFooter = styled.footer`
   }
 `;
 
+export const StyledHeader = styled.header`
+  padding-top: 15px;
+  padding-bottom: 15px;
+  width: 100%;
+
+  ${({ theme }) => theme.colors.header};
+
+  .column {
+    display: flex;
+    flex-direction: row-reverse;
+  }
+
+`;
+
 export const MainWrapper = styled(Container)`
 
   h1 {
@@ -29,5 +43,4 @@ export const MainWrapper = styled(Container)`
   .column {
     margin-top: 20%;
   }
-
 `;

--- a/src/components/Links/Links.tsx
+++ b/src/components/Links/Links.tsx
@@ -12,23 +12,23 @@ import { LinkContainer } from './styles';
 
 
 const GitHubLink = () =>
-    <LogoWithLink Logo={GitHub} href={hrefs.github} message={messages.github} />;
+  <LogoWithLink Logo={GitHub} href={hrefs.github} message={messages.github} />;
 
 const LinkedInLink = () =>
-    <LogoWithLink Logo={LinkedIn} href={hrefs.linkedin} message={messages.linkedin} />;
+  <LogoWithLink Logo={LinkedIn} href={hrefs.linkedin} message={messages.linkedin} />;
 
 const ResumeLink = () =>
-    <LogoWithLink Logo={Resume} href={hrefs.resume} message={messages.resume} />;
+  <LogoWithLink Logo={Resume} href={hrefs.resume} message={messages.resume} />;
 
 
 const Links = () => {
-    return (
-        <LinkContainer>
-            <GitHubLink />
-            <LinkedInLink />
-            <ResumeLink />
-        </LinkContainer>
-    );
+  return (
+    <LinkContainer>
+      <GitHubLink />
+      <LinkedInLink />
+      <ResumeLink />
+    </LinkContainer>
+  );
 }
 
 export default Links;

--- a/src/components/ThemeToggle/Moon.tsx
+++ b/src/components/ThemeToggle/Moon.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import styled from 'styled-components';
+import { IconProps } from '../../icons/types';
+
+const MoonSvg = () => (
+  <svg fill="currentcolor" xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 292.299 292.299">
+    <path d="M153.699,292.138C68.95,292.138,0,223.185,0,138.439C0,79.742,32.675,27.002,85.28,0.807
+			c2.369-1.174,5.215-0.718,7.077,1.144c1.864,1.864,2.345,4.711,1.183,7.074C83.941,28.527,79.077,49.496,79.077,71.33
+			c0,77.972,63.432,141.407,141.395,141.407c22.08,0,43.247-4.978,62.942-14.777c2.366-1.177,5.213-0.721,7.074,1.141
+			c1.873,1.867,2.342,4.714,1.177,7.073C265.61,259.195,212.738,292.138,153.699,292.138z"/>
+  </svg>);
+
+const LogoWrapper = styled.div<IconProps>`
+  ${({ placement }) => {
+
+    if (placement === 'onHandle')
+      return 'width:22px; height:22px;';
+
+    if (placement === 'offHandle')
+      return 'width:20px; height:24px;';
+  }}
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+    svg {
+      width: 12px;
+      color: ${({ theme }) => 'yellow'};
+    }
+`;
+
+const Moon = ({ placement }: IconProps) => {
+  return (
+    <LogoWrapper placement={placement}>
+      <MoonSvg />
+    </LogoWrapper>
+  );
+}
+
+
+export default Moon;

--- a/src/components/ThemeToggle/Sun.tsx
+++ b/src/components/ThemeToggle/Sun.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import styled from 'styled-components';
+import { IconProps } from '../../icons/types';
+
+const SunSvg = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 420 420" fill="currentColor">
+    <polygon fill="#F8A805" points="420,210 375.774,247.857 399.238,301.145 342.926,315.986 340.945,374.184 283.764,363.211 
+		256.724,414.779 210,380 163.276,414.779 136.236,363.211 79.055,374.184 77.073,315.986 20.762,301.144 44.226,247.858 0,210 
+		44.226,172.143 20.762,118.855 77.074,104.014 79.055,45.816 136.236,56.789 163.276,5.221 210,40 256.723,5.221 283.764,56.789 
+		340.945,45.816 342.927,104.014 399.238,118.856 375.774,172.142 	"/>
+    <circle fill="#F8A805" cx="210" cy="210" r="140" />
+  </svg>);
+
+const LogoWrapper = styled.div<IconProps>`
+  ${({ placement }) => {
+
+    if (placement === 'onHandle')
+      return 'width:22px; height:22px;';
+
+    if (placement === 'offHandle')
+      return 'width:22px; height:24px;';
+  }}
+
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+  svg {
+    width: 16px;
+    height: 16px;
+  }
+`;
+
+const Sun = ({ placement }: IconProps) => {
+  return (
+    <LogoWrapper placement={placement}>
+      <SunSvg />
+    </LogoWrapper>
+  );
+}
+
+
+export default Sun;

--- a/src/components/ThemeToggle/ThemeToggle.tsx
+++ b/src/components/ThemeToggle/ThemeToggle.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import Switch from 'react-switch';
+
+import { ColorSchemeContext } from '../../context/ColorSchemeContext';
+
+import Moon from './Moon';
+import Sun from './Sun';
+
+const ThemeToggle = () => {
+  const { appearance, toggleTheme } = React.useContext(ColorSchemeContext);
+
+  const handleSwitch = () => {
+    toggleTheme();
+  }
+
+  return (
+    <Switch onChange={handleSwitch}
+      checked={appearance === 'dark'}
+      onColor={'#f8f9fa'}
+      offColor={'#343a40'}
+      onHandleColor={'#343a40'}
+      offHandleColor={'#f8f9fa'}
+      checkedHandleIcon={<Moon placement='onHandle' />}
+      uncheckedHandleIcon={<Sun placement='onHandle' />}
+      uncheckedIcon={<Moon placement='offHandle' />}
+      checkedIcon={<Sun placement='offHandle' />}
+      handleDiameter={22}
+      height={24}
+      width={42}
+      borderRadius={12}
+    />
+  );
+}
+
+export default ThemeToggle;

--- a/src/icons/types.ts
+++ b/src/icons/types.ts
@@ -1,0 +1,3 @@
+export interface IconProps {
+  placement?: 'onHandle' | 'offHandle';
+};

--- a/src/themes/theme.ts
+++ b/src/themes/theme.ts
@@ -7,7 +7,11 @@ export const lightTheme: DefaultTheme = {
     primary: '#343a40',
     background: '#f8f9fa',
     footer: {
-      backgroundColor: '#242a20',
+      backgroundColor: '#eff2f5',
+      color: '#343a40'
+    },
+    header: {
+      backgroundColor: '#eff2f5',
       color: '#f8f9fa'
     },
     anchor: {
@@ -22,6 +26,10 @@ export const darkTheme: DefaultTheme = {
     primary: '#f8f9fa',
     background: '#343a40',
     footer: {
+      backgroundColor: '#727271',
+      color: '#f8f9fa'
+    },
+    header: {
       backgroundColor: '#727271',
       color: '#f8f9fa'
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -8150,7 +8150,7 @@ prompts@^2.0.1, prompts@^2.4.2:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.8.1:
+prop-types@^15.7.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -8373,6 +8373,13 @@ react-scripts@5.0.1:
     workbox-webpack-plugin "^6.4.1"
   optionalDependencies:
     fsevents "^2.3.2"
+
+react-switch@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/react-switch/-/react-switch-7.0.0.tgz#400990bb9822864938e343ed24f13276a617bdc0"
+  integrity sha512-KkDeW+cozZXI6knDPyUt3KBN1rmhoVYgAdCJqAh7st7tk8YE6N0iR89zjCWO8T8dUTeJGTR0KU+5CHCRMRffiA==
+  dependencies:
+    prop-types "^15.7.2"
 
 react@^18.3.1:
   version "18.3.1"


### PR DESCRIPTION
# Background
I have previously added light/dark color theme and it would follow the user's OS settings. Now we have a switch that can override OS settings.

# in this update
- Added react-switch for the toggle
- Added sun & moon icons
- Added Header component
